### PR TITLE
added: improve function to work on every portion of subwords

### DIFF
--- a/subword-mode-expansions.el
+++ b/subword-mode-expansions.el
@@ -32,9 +32,14 @@
   "Mark a subword, a part of a CamelCase identifier."
   (interactive)
   (when expand-region-subword-enabled
-    (subword-right 1)
-    (set-mark (point))
-    (subword-left 1)))
+    (if mark-active
+        (progn
+          (exchange-point-and-mark)
+          (subword-right 1)
+          (exchange-point-and-mark))
+      (subword-right 1)
+      (set-mark (point))
+      (subword-left 1))))
 
 (defun er/add-subword-mode-expansions ()
   "Add expansions for buffers in `subword-mode'."


### PR DESCRIPTION
The following code reproduces the expected behavior that I asked you in the #1 

~ emacs-lisp-mode
`(setq |CamelCaseTest t)`

After er/expand-region:
`(setq Camel|CaseTest t)`

One more time:
`(setq CamelCaseTest| t)`

**I would expect the following:**
`(setq CamelCase|Test t)`


Now, after every `er/expand-region` you will move exactly the same amount of `subword-right` would.

Can you evaluate this behavioral change?
