### PR TITLE
added: toggle status of this package to follow subword-mode

### DIFF
--- a/expand-region-subword.el
+++ b/expand-region-subword.el
@@ -38,5 +38,11 @@
 
 (eval-after-load 'subword '(require 'subword-mode-expansions))
 
+(defadvice subword-mode (before er/toggle-expand-subword activate)
+  "Toggle `expand-region-subword' based on the status of `subword-mode'."
+  (if subword-mode
+      (setq expand-region-subword-enabled nil)
+    (setq expand-region-subword-enabled t)))
+
 (provide 'expand-region-subword)
 ;;; expand-region-subword.el ends here


### PR DESCRIPTION
@flatwhatson I really don't know if what I thought is best practice when writing packages in Emacs.

I would like to have this functionality toggling with the same status of `subword-mode`, but the problem is the following:

If I activate `subword-mode`; this package will activate.
If I deactivate `subword-mode`; this package **should** deactivate as well.
What you think?

(sorry, I messed up some branch and did the PR separated)